### PR TITLE
Avoid exception when stylesheet has no style rules.

### DIFF
--- a/pykss/contrib/django/static/pykss/js/kss.js
+++ b/pykss/contrib/django/static/pykss/js/kss.js
@@ -12,13 +12,15 @@
           stylesheet = _ref[_i];
           idxs = [];
           _ref2 = stylesheet.cssRules;
-          for (idx = 0, _len2 = _ref2.length; idx < _len2; idx++) {
-            rule = _ref2[idx];
-            if ((rule.type === CSSRule.STYLE_RULE) && pseudos.test(rule.selectorText)) {
-              replaceRule = function(matched, stuff) {
-                return matched.replace(/\:/g, '.pseudo-class-');
-              };
-              this.insertRule(rule.cssText.replace(pseudos, replaceRule));
+          if (_ref2) {
+            for (idx = 0, _len2 = _ref2.length; idx < _len2; idx++) {
+              rule = _ref2[idx];
+              if ((rule.type === CSSRule.STYLE_RULE) && pseudos.test(rule.selectorText)) {
+                replaceRule = function(matched, stuff) {
+                  return matched.replace(/\:/g, '.pseudo-class-');
+                };
+                this.insertRule(rule.cssText.replace(pseudos, replaceRule));
+              }
             }
           }
         }


### PR DESCRIPTION
In some cases JS parser (kss.js) does not work as expected.
I have a stylesheet from Typekit that is included before any other stylesheets.
All it has is `@font-face` at-rules.

These rules will not be retrieved here:

``` javascript
ref2 = stylesheet.cssRules;
```

As a result `_ref2` is `null` and exception thrown on the following line

``` javascript
for (idx = 0, _len2 = _ref2.length; idx < _len2; idx++) {
```

That results in termination of the outer loop (line 11) and consequently none of the remaining stylesheets that were included after the Typekit stylesheet are parsed.

Since this project probably compiles CoffeeScript from http://github.com/kneath/kss I am not sure whether or not it makes sense to have this bug fixed here. I am going to send a pull request for CoffeeScript as well in the KSS project.
