### PR TITLE
Adds multiline modifier support

### DIFF
--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -13,8 +13,11 @@ Your standard form button.
 
 :hover    - Highlights when hovering.
 :disabled - Dims the button when disabled.
-.primary  - Indicates button is the primary action.
+.primary  - Indicates button
+            is the primary action.
 .smaller  - A smaller button
+
+    This is part of the description, not a multiline modifier.
 
 Example:
     <a href="#" class="button$modifier_class">Button</a><a href="#"[ class="$modifier_class"]?>Button</a>
@@ -24,7 +27,10 @@ Styleguide 2.1.1.
         self.section = Section(comment.strip(), 'example.css')
 
     def test_parses_the_description(self):
-        self.assertEqual(self.section.description, '# Form Button\n\nYour standard form button.')
+        self.assertEqual(self.section.description,
+                         ('# Form Button\n\nYour standard form button.\n\n\n'
+                          '    This is part of the description, '
+                          'not a multiline modifier.'))
 
     def test_parses_the_modifiers(self):
         self.assertEqual(len(self.section.modifiers), 4)
@@ -34,6 +40,10 @@ Styleguide 2.1.1.
 
     def test_parses_modifier_descriptions(self):
         self.assertEqual(self.section.modifiers[0].description, 'Highlights when hovering.')
+
+    def test_parses_modifier_multiline_descriptions(self):
+        self.assertEqual(self.section.modifiers[2].description,
+                         'Indicates button is the primary action.')
 
     def test_parses_the_example(self):
         expected = '<a href="#" class="button">Button</a><a href="#">Button</a>'


### PR DESCRIPTION
The KSS spec is vague on multiline support, but the ruby and node KSS implementations both support multiline modifier statements. I've opened see kneath/kss#105 to address multiline support in the spec. This adds multiline modifier support and required tests to pykss.

This changes the section parsing, adding state to track if a modifier block is being parsed still. If a modifier block has already begun, and a multiline statement match occurs, append to the last modifier description. If the modifier block ends, unmatched content still goes into the description.
