### PR TITLE
Filter filename extensions in path walk

### DIFF
--- a/pykss/contrib/django/views.py
+++ b/pykss/contrib/django/views.py
@@ -8,7 +8,8 @@ class StyleguideMixin(object):
 
     def get_styleguide(self):
         dirs = getattr(settings, 'PYKSS_DIRS', [])
-        return pykss.Parser(*dirs)
+        exts = getattr(settings, 'PYKSS_EXTENSIONS', None)
+        return pykss.Parser(*dirs, extensions=exts)
 
     def get_context_data(self, **kwargs):
         context = super(StyleguideMixin, self).get_context_data(**kwargs)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -12,6 +12,7 @@ class ParseTestCase(unittest.TestCase):
         self.less = pykss.Parser(os.path.join(fixtures, 'less'))
         self.sass = pykss.Parser(os.path.join(fixtures, 'sass'))
         self.css = pykss.Parser(os.path.join(fixtures, 'css'))
+        self.na = pykss.Parser(os.path.join(fixtures, 'scss'), extensions=['.css'])
         self.multiple = pykss.Parser(os.path.join(fixtures, 'scss'), os.path.join(fixtures, 'less'))
 
     def test_parses_kss_comments_in_scss(self):
@@ -46,3 +47,6 @@ class ParseTestCase(unittest.TestCase):
 
     def test_parse_multiple_paths(self):
         self.assertEqual(len(self.multiple.sections), 6)
+
+    def test_parse_ext_mismatch(self):
+        self.assertDictEqual(self.na.sections, {})


### PR DESCRIPTION
Ignore non-css related extensions when finding files to parse. Adds argument to
control extensions on instantiation, and a setting for the contrib django
application.
